### PR TITLE
Add article creation tests with test steps

### DIFF
--- a/src/pages/CreateArticlePage.js
+++ b/src/pages/CreateArticlePage.js
@@ -7,14 +7,89 @@ export class CreateArticlePage {
       name: 'Publish Article',
     });
     this.errorMessage = page.getByRole('list').nth(1);
+    this.titleField = page.getByPlaceholder('Article Title');
+    this.descriptionField = page.getByPlaceholder(
+      "What's this article about?",
+    );
+    this.bodyField = page.getByPlaceholder('Write your article (in markdown)');
+    this.tagField = page.getByPlaceholder('Enter tags');
   }
 
+  /**
+   * Open the 'Create Article' page
+   * @returns {Promise<void>}
+   */
+  async open() {
+    await test.step(`Open the 'Create Article' page`, async () => {
+      await this.page.goto('/editor');
+    });
+  }
+
+  /**
+   * Fill the 'Title' field with the given title
+   * @param {string} title - Title to fill
+   * @returns {Promise<void>}
+   */
+  async fillTitle(title) {
+    await test.step(`Fill the 'Title' field with '${title}'`, async () => {
+      await this.titleField.fill(title);
+    });
+  }
+
+  /**
+   * Fill the 'Description' field with the given description
+   * @param {string} description - Description to fill
+   * @returns {Promise<void>}
+   */
+  async fillDescription(description) {
+    await test.step(
+      `Fill the 'Description' field with '${description}'`,
+      async () => {
+        await this.descriptionField.fill(description);
+      },
+    );
+  }
+
+  /**
+   * Fill the 'Body' field with the given body
+   * @param {string} body - Body to fill
+   * @returns {Promise<void>}
+   */
+  async fillText(body) {
+    await test.step(`Fill the 'Body' field with '${body}'`, async () => {
+      await this.bodyField.fill(body);
+    });
+  }
+
+  /**
+   * Fill the 'Tag' field with the given tags
+   * @param {string[]} tags - Array of tags to fill
+   * @returns {Promise<void>}
+   */
+  async fillTag(tags) {
+    await test.step(`Fill the 'Tag' field with '${tags}'`, async () => {
+      for (const tag of tags) {
+        await this.tagField.fill(tag);
+        await this.tagField.press('Enter');
+      }
+    });
+  }
+
+  /**
+   * Click the 'Publish Article' button
+   * @returns {Promise<void>}
+   */
   async clickPublishArticleButton() {
     await test.step(`Click the 'Publish Article' button`, async () => {
       await this.publishArticleButton.click();
     });
   }
 
+  /**
+   * Assert the error message contains the given text
+   * @param {string} messageText - Text to assert
+   * @returns {Promise<void>}
+   */
   async assertErrorMessageContainsText(messageText) {
     await test.step(`Assert the '${messageText}' error is shown`, async () => {
       await expect(this.errorMessage).toContainText(messageText);

--- a/src/pages/CreateArticlePage.js
+++ b/src/pages/CreateArticlePage.js
@@ -90,6 +90,17 @@ export class CreateArticlePage {
    * @param {string} messageText - Text to assert
    * @returns {Promise<void>}
    */
+  /**
+   * Assert the article title is visible on the article page
+   * @param {string} title - Expected article title
+   * @returns {Promise<void>}
+   */
+  async assertArticleTitleIsVisible(title) {
+    await test.step(`Assert the article title '${title}' is visible`, async () => {
+      await expect(this.page.getByRole('heading', { name: title, level: 1 })).toBeVisible();
+    });
+  }
+
   async assertErrorMessageContainsText(messageText) {
     await test.step(`Assert the '${messageText}' error is shown`, async () => {
       await expect(this.errorMessage).toContainText(messageText);

--- a/tests/createArticle/createArticleWithoutRequiredFields.spec.js
+++ b/tests/createArticle/createArticleWithoutRequiredFields.spec.js
@@ -34,6 +34,7 @@ test('Create an article with required and optional fields', async () => {
   await createArticlePage.fillTag(['Test Tag']);
 
   await createArticlePage.clickPublishArticleButton();
+  await createArticlePage.assertArticleTitleIsVisible('Test Title');
 });
 
 test('Create an article without required fields', async () => {
@@ -72,9 +73,9 @@ test('Create an article without text field', async () => {
 test('Create an article without tag field', async () => {
   await homePage.clickNewArticleLink();
   await createArticlePage.fillTitle('Test Title');
-  await createArticlePage.fillDescription('Test Article Text');
+  await createArticlePage.fillDescription('Test Description');
   await createArticlePage.fillText('Test Article Text');
 
   await createArticlePage.clickPublishArticleButton();
-  await createArticlePage.assertErrorMessageContainsText('');
+  await createArticlePage.assertArticleTitleIsVisible('Test Title');
 });

--- a/tests/createArticle/createArticleWithoutRequiredFields.spec.js
+++ b/tests/createArticle/createArticleWithoutRequiredFields.spec.js
@@ -26,11 +26,55 @@ test.beforeEach(async ({ page }) => {
   await homePage.assertYourFeedTabIsVisible();
 });
 
-test('Creat an article without required fields', async () => {
+test('Create an article with required and optional fields', async () => {
+  await homePage.clickNewArticleLink();
+  await createArticlePage.fillTitle('Test Title');
+  await createArticlePage.fillDescription('Test Description');
+  await createArticlePage.fillText('Test Article Text');
+  await createArticlePage.fillTag(['Test Tag']);
+
+  await createArticlePage.clickPublishArticleButton();
+});
+
+test('Create an article without required fields', async () => {
   await homePage.clickNewArticleLink();
 
   await createArticlePage.clickPublishArticleButton();
   await createArticlePage.assertErrorMessageContainsText(
     'Article title cannot be empty',
   );
+});
+
+test('Create an article without description field', async () => {
+  await homePage.clickNewArticleLink();
+  await createArticlePage.fillTitle('Test Title');
+  await createArticlePage.fillText('Test Article Text');
+  await createArticlePage.fillTag(['Test Tag']);
+
+  await createArticlePage.clickPublishArticleButton();
+  await createArticlePage.assertErrorMessageContainsText(
+    'Article description cannot be empty',
+  );
+});
+
+test('Create an article without text field', async () => {
+  await homePage.clickNewArticleLink();
+  await createArticlePage.fillTitle('Test Title');
+  await createArticlePage.fillDescription('Test Article Text');
+  await createArticlePage.fillTag(['Test Tag']);
+
+  await createArticlePage.clickPublishArticleButton();
+  await createArticlePage.assertErrorMessageContainsText(
+    'Article body cannot be empty',
+  );
+});
+
+test('Create an article without tag field', async () => {
+  await homePage.clickNewArticleLink();
+  await createArticlePage.fillTitle('Test Title');
+  await createArticlePage.fillDescription('Test Article Text');
+  await createArticlePage.fillText('Test Article Text');
+
+  await createArticlePage.clickPublishArticleButton();
+  await createArticlePage.assertErrorMessageContainsText('');
 });

--- a/tests/createArticle/createArticleWithoutRequiredFields.spec.js
+++ b/tests/createArticle/createArticleWithoutRequiredFields.spec.js
@@ -61,7 +61,7 @@ test('Create an article without description field', async () => {
 test('Create an article without text field', async () => {
   await homePage.clickNewArticleLink();
   await createArticlePage.fillTitle('Test Title');
-  await createArticlePage.fillDescription('Test Article Text');
+  await createArticlePage.fillDescription('Test Description');
   await createArticlePage.fillTag(['Test Tag']);
 
   await createArticlePage.clickPublishArticleButton();


### PR DESCRIPTION
## Summary
- Add 4 new tests for Conduit article creation (with all fields, without description, without text, without tag)
- Update CreateArticlePage POM with fillTitle, fillDescription, fillText, fillTag methods
- Fix missing await in fillTag loop
- Add test.step for each method in page classes

## Test plan
- [x] All 5 tests pass locally